### PR TITLE
Bump referenced version of SpiceDB

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,7 +4,7 @@ on:
       - main
   release:
     types:
-      - created
+      - published
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 out
 dist
 node_modules
+yarn.lock
+src/check-watch-panel/public/main.wasm
 .vscode-test/
 *.vsix

--- a/download-wasm.sh
+++ b/download-wasm.sh
@@ -1,1 +1,1 @@
-wget https://github.com/authzed/spicedb/releases/download/v1.34.0/development.wasm -O src/check-watch-panel/public/main.wasm
+wget https://github.com/authzed/spicedb/releases/download/v1.37.0/development.wasm -O src/check-watch-panel/public/main.wasm


### PR DESCRIPTION
Should address #20 

## Description
This should get `.all` syntax working in VSCode.

## Changes
* Add generated files to .gitignore
* Change trigger to release publish
* Add more things to gitignore
## Testing
Review