### PR TITLE
fix definition grammar

### DIFF
--- a/syntaxes/spicedb.tmGrammar.json
+++ b/syntaxes/spicedb.tmGrammar.json
@@ -37,7 +37,7 @@
     },
     "definition": {
       "comment": "definition of a resource type in schema",
-      "begin": "(\\bdefinition\\b)\\s+([a-zA-Z_]\\w*)\\s*(\\{)",
+      "begin": "(\\bdefinition\\b)\\s+(([a-z][\\w]{1,62}[a-z0-9]\\/)*[a-z][\\w]{1,62}[a-z0-9])\\s*(\\{)",
       "beginCaptures": {
         "1": {
           "name": "keyword.class.definition"
@@ -45,7 +45,7 @@
         "2": {
           "name": "entity.name.class"
         },
-        "3": {
+        "4": {
           "name": "punctuation.definition.brace"
         }
       },


### PR DESCRIPTION
Fixes #19 
The definition pattern did not match the proper `definition` grammar and did not allow for prefixes.
I pulled the updated pattern from [tree-sitter-spicedb](https://github.com/authzed/tree-sitter-spicedb/blob/main/grammar.js#L37).

<img width="580" alt="Screenshot 2025-01-10 at 12 00 27" src="https://github.com/user-attachments/assets/cad7ec4b-8880-4d1b-97db-19f2898075ee" />

<img width="702" alt="Screenshot 2025-01-10 at 12 00 34" src="https://github.com/user-attachments/assets/c1f61d28-132a-4e39-93be-8fef611fce73" />

<img width="823" alt="Screenshot 2025-01-10 at 12 00 48" src="https://github.com/user-attachments/assets/6bfa8caa-4f6a-4b65-9bac-2716655fef1b" />
