### PR TITLE
ci: publish workflow improvements

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: 'Run typechecking'
         run: 'CI=true yarn run tsc -noEmit'
       - name: 'Run prettier'
-        run: 'CI=true yarn run format:check'
+        run: 'CI=true yarn run format'
       - name: 'Run lint'
         run: 'CI=true yarn run lint'
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,10 +1,11 @@
+name: 'Publish'
 on:
   release:
     types:
       - published
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -21,7 +22,39 @@ jobs:
           echo Version: $VERSION
           echo "VERSION=$VERSION" >> $GITHUB_ENV
       - run: 'npm version ${VERSION} --no-git-tag-version'
-      - name: Publish
-        run: yarn deploy
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+      - name: Publish to Open VSX Registry
+        uses: HaaLeo/publish-vscode-extension@v2
+        with:
+          yarn: 'false'
+          skipDuplicate: 'true'
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+      - name: Publish to Visual Studio Marketplace
+        uses: HaaLeo/publish-vscode-extension@v2
+        with:
+          yarn: 'false'
+          skipDuplicate: 'true'
+          pat: ${{ secrets.VSCE_PAT }}
+          registryUrl: https://marketplace.visualstudio.com/
+      - name: Build VSIX
+        run: yarn run vscode:build
+      - name: Upload VSIX to release
+        uses: actions/upload-artifact@v6
+        with:
+          path: ./spicedb.vsix
+          name: spicedb.vsix
+          if-no-files-found: 'error'
+      - name: 'Notify in Slack if failure'
+        if: '${{ failure() }}'
+        uses: 'slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a' # v2.1.1
+        with:
+          webhook: '${{ secrets.SLACK_BUILDS_WEBHOOK_URL }}'
+          webhook-type: 'incoming-webhook'
+          payload: |
+            text: "VSCode Release failure."
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: |
+                    :x: @eng-oss VSCode Release failure. Please take a look.
+                    *Repository:* <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,2 +1,11 @@
+.github
+.idea
+.vscode
+.gitignore
 src/check-watch-panel/node_modules
 !src/check-watch-panel/node_modules/@vscode/codicons/dist
+CODE-OF-CONDUCT.md
+build-panels.sh
+download-wasm.sh
+eslint.config.mjs
+src

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/authzed/spicedb-vscode.git"
   },
   "engines": {
-    "vscode": "^1.87.0"
+    "vscode": "^1.106.1"
   },
   "extensionKind": [
     "ui",
@@ -91,18 +91,18 @@
   "activationEvents": [],
   "main": "./out/extension.js",
   "scripts": {
+    "vscode:build": "vsce package -o spicedb.vsix --no-yarn",
     "vscode:prepublish": "yarn run compile",
+    "vscode:publish": "vsce publish --no-yarn",
     "download-wasm": "./download-wasm.sh",
-    "build-panels": "./build-panels.sh",
-    "compile": "tsc -p ./ && yarn run build-panels",
+    "compile": "tsc -p ./ && sh ./build-panels.sh",
     "watch": "tsc -watch -p ./",
     "pretest": "yarn run compile && yarn run lint",
-    "lint": "eslint",
-    "format:check": "prettier -c .",
-    "format": "prettier -w .",
-    "lint:fix": "eslint --fix",
     "test": "vscode-test",
-    "deploy": "vsce publish --no-yarn"
+    "lint": "eslint",
+    "lint:fix": "eslint --fix",
+    "format": "prettier -c .",
+    "format:fix": "prettier -w ."
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.3",


### PR DESCRIPTION
- allow to publish to OpenVSX. see also: https://github.com/EclipseFdn/open-vsx.org/issues/7066
- edit the yarn targets