### PR TITLE
feat: embed CEL and fix SpiceDB grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,7 @@ installation mechanism you originally used.
 ### Built-in check watch
 
 <img src="assets/check-watches.gif" height="450">
+
+## Acknowledgments
+
+The syntax for the CEL language (used in caveats) was copied from [vscode-cel](https://github.com/hmarr/vscode-cel).

--- a/package.json
+++ b/package.json
@@ -22,6 +22,13 @@
   "contributes": {
     "languages": [
       {
+        "id": "cel",
+        "aliases": [
+          "CEL",
+          "cel"
+        ]
+      },
+      {
         "id": "spicedb",
         "aliases": [
           "SpiceDB",
@@ -40,6 +47,11 @@
       }
     ],
     "grammars": [
+      {
+        "language": "cel",
+        "scopeName": "source.cel",
+        "path": "./syntaxes/cel.tmGrammar.json"
+      },
       {
         "language": "spicedb",
         "scopeName": "source.spicedb",
@@ -85,9 +97,6 @@
       ]
     }
   },
-  "extensionDependencies": [
-    "hmarr.cel"
-  ],
   "activationEvents": [],
   "main": "./out/extension.js",
   "scripts": {

--- a/syntaxes/cel.tmGrammar.json
+++ b/syntaxes/cel.tmGrammar.json
@@ -1,0 +1,307 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "cel",
+  "scopeName": "source.cel",
+  "patterns": [
+    {
+      "include": "#comments"
+    },
+    {
+      "include": "#expressions"
+    }
+  ],
+  "repository": {
+    "expressions": {
+      "patterns": [
+        {
+          "include": "#reserved-identifiers"
+        },
+        {
+          "include": "#function-calls"
+        },
+        {
+          "include": "#object-constructions"
+        },
+        {
+          "include": "#parens"
+        },
+        {
+          "include": "#lists"
+        },
+        {
+          "include": "#maps"
+        },
+        {
+          "include": "#numbers"
+        },
+        {
+          "include": "#strings"
+        },
+        {
+          "include": "#langauge-constants"
+        },
+        {
+          "include": "#operators"
+        }
+      ]
+    },
+    "reserved-identifiers": {
+      "patterns": [
+        {
+          "name": "invalid.illegal.cel",
+          "match": "\\b(as|break|const|continue|else|for|function|if|import|let|loop|package|namespace|return|var|void|while)\\b"
+        }
+      ]
+    },
+    "function-calls": {
+      "match": "([_a-zA-Z][_a-zA-Z0-9]+)(?=\\()",
+      "captures": {
+        "1": {
+          "name": "variable.function.cel"
+        }
+      }
+    },
+    "object-constructions": {
+      "name": "meta.structure.object.cel",
+      "begin": "([_a-zA-Z][_a-zA-Z0-9]+)(\\{)",
+      "beginCaptures": {
+        "1": {
+          "name": "variable.object.cel"
+        },
+        "2": {
+          "name": "punctuation.definition.object.begin.cel"
+        }
+      },
+      "end": "\\}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.object.end.cel"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#object-kv"
+        }
+      ]
+    },
+    "object-kv": {
+      "begin": "([_a-zA-Z][_a-zA-Z0-9]*:)",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.type.attribute-name.cel"
+        }
+      },
+      "end": "(,)|(?=\\})",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.separator.object.cel"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#expressions"
+        }
+      ]
+    },
+    "parens": {
+      "begin": "\\(",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.parenthesis.begin.cel"
+        }
+      },
+      "end": "\\)",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.parenthesis.end.cel"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#expressions"
+        }
+      ]
+    },
+    "maps": {
+      "name": "meta.structure.map.cel",
+      "begin": "\\{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.map.begin.cel"
+        }
+      },
+      "end": "\\}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.map.end.cel"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#expressions"
+        },
+        {
+          "name": "punctuation.separator.map.cel",
+          "match": ",|:"
+        }
+      ]
+    },
+    "lists": {
+      "name": "meta.structure.list.cel",
+      "begin": "\\[",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.list.begin.cel"
+        }
+      },
+      "end": "\\]",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.list.end.cel"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#expressions"
+        },
+        {
+          "name": "punctuation.separator.list.cel",
+          "match": ","
+        }
+      ]
+    },
+    "comments": {
+      "name": "comment.line.double-slash.cel",
+      "begin": "(\\/\\/)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.comment.cel"
+        }
+      },
+      "end": "(?:\\n|$)"
+    },
+    "strings": {
+      "patterns": [
+        {
+          "include": "#string-multi-line"
+        },
+        {
+          "include": "#string-raw-multi-line"
+        },
+        {
+          "include": "#string-single-line"
+        },
+        {
+          "include": "#string-raw-single-line"
+        }
+      ]
+    },
+    "string-single-line": {
+      "comment": "single-line string",
+      "name": "string.quoted.single.cel",
+      "begin": "(['\"])",
+      "end": "(\\1|$)",
+      "patterns": [
+        {
+          "include": "#string-escape-sequence"
+        }
+      ]
+    },
+    "string-raw-single-line": {
+      "comment": "raw single-line double-quoted string",
+      "name": "string.quoted.single.cel",
+      "begin": "([rR])(['\"])",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.type.raw-string.cel"
+        }
+      },
+      "end": "(\\2|$)"
+    },
+    "string-multi-line": {
+      "comment": "multi-line string",
+      "name": "string.quoted.triple.cel",
+      "begin": "(['\"]{3})",
+      "end": "(\\1)",
+      "patterns": [
+        {
+          "include": "#string-escape-sequence"
+        }
+      ]
+    },
+    "string-raw-multi-line": {
+      "comment": "raw multi-line double-quoted string",
+      "name": "string.quoted.triple.cel",
+      "begin": "([rR])(['\"]{3})",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.type.raw-string.cel"
+        }
+      },
+      "end": "(\\2)"
+    },
+    "string-escape-sequence": {
+      "patterns": [
+        {
+          "name": "constant.character.escape.cel",
+          "match": "\\\\[bfnrt\"'\\\\]"
+        },
+        {
+          "name": "constant.character.escape.cel",
+          "match": "\\\\u[0-9a-fA-F]{4}"
+        },
+        {
+          "name": "constant.character.escape.cel",
+          "match": "\\\\U[0-9a-fA-F]{8}"
+        },
+        {
+          "name": "constant.character.escape.cel",
+          "match": "\\\\[xX][0-9a-fA-F]{2}"
+        },
+        {
+          "name": "constant.character.escape.cel",
+          "match": "\\\\0[0-8]{3}"
+        }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "comment": "float literal with decimals",
+          "name": "constant.numeric.floating-point.cel",
+          "match": "([0-9]*\\.[0-9]+([eE][+-]?[0-9]+)?)"
+        },
+        {
+          "comment": "float literal with exponent",
+          "name": "constant.numeric.floating-point.cel",
+          "match": "([0-9]+[eE][+-]?[0-9]+)"
+        },
+        {
+          "comment": "int or uint literal",
+          "name": "constant.numeric.integer.cel",
+          "match": "([0-9]+|0x[0-9a-fA-F]+)[uU]?"
+        }
+      ]
+    },
+    "langauge-constants": {
+      "name": "constant.language.cel",
+      "match": "\\b(true|false|null)\\b"
+    },
+    "operators": {
+      "patterns": [
+        {
+          "name": "keyword.operator.logical.cel",
+          "match": "(&&|\\|\\|)"
+        },
+        {
+          "name": "keyword.operator.comparison.cel",
+          "match": "(<=|<|>=|>|==|!=|(?<=[^A-Za-z_])in\\b)"
+        },
+        {
+          "name": "keyword.operator.arithmetic.cel",
+          "match": "(\\+|\\-|\\*|\\/|\\%|\\!)"
+        }
+      ]
+    }
+  }
+}

--- a/syntaxes/spicedb.tmGrammar.json
+++ b/syntaxes/spicedb.tmGrammar.json
@@ -6,6 +6,7 @@
   "foldingStopMarker": "^\\s*\\}",
   "patterns": [
     { "include": "#comment" },
+    { "include": "#use" },
     { "include": "#definition" },
     { "include": "#caveat" },
     { "include": "#relation" },
@@ -77,6 +78,8 @@
         { "include": "#indirectRelationType" },
         { "include": "#directRelationType" },
         { "include": "#pipe" },
+        { "include": "#with_caveat" },
+        { "include": "#with_expiration" },
         { "include": "#comment" }
       ]
     },
@@ -141,6 +144,8 @@
       "end": "(?<=\\;|\\n)",
       "patterns": [
         { "include": "#comment" },
+        { "include": "#arrow_alternative" },
+        { "include": "#arrow_intersection" },
         { "include": "#arrow" },
         { "include": "#nil" },
         { "include": "#relationRef" },
@@ -177,6 +182,36 @@
     "arrow": {
       "comment": "arrow",
       "match": "\\s*([a-zA-Z_]\\w*)(\\-\\>)([a-zA-Z_]\\w*)\\s*",
+      "captures": {
+        "1": {
+          "name": "entity.name.variable"
+        },
+        "2": {
+          "name": "keyword.operator.arrow markup.bold.authzed"
+        },
+        "3": {
+          "name": "entity.name.variable"
+        }
+      }
+    },
+    "arrow_alternative": {
+      "comment": "arrow_alternative",
+      "match": "\\s*([a-zA-Z_]\\w*)(\\.any)\\(([a-zA-Z_]\\w*)\\)\\s*",
+      "captures": {
+        "1": {
+          "name": "entity.name.variable"
+        },
+        "2": {
+          "name": "keyword.operator.arrow markup.bold.authzed"
+        },
+        "3": {
+          "name": "entity.name.variable"
+        }
+      }
+    },
+    "arrow_intersection": {
+      "comment": "arrow_alternative",
+      "match": "\\s*([a-zA-Z_]\\w*)(\\.all)\\(([a-zA-Z_]\\w*)\\)\\s*",
       "captures": {
         "1": {
           "name": "entity.name.variable"
@@ -240,6 +275,42 @@
       "comment": "comma",
       "match": "\\s*\\,\\s*",
       "name": "punctuation.definition.comma"
+    },
+    "use": {
+      "comment": "use",
+      "match": "\\s*(use)\\s*([a-zA-Z_]\\w*)\\s*",
+      "captures": {
+        "1": {
+          "name": "keyword.class.definition"
+        },
+        "2": {
+          "name": "keyword.class.definition"
+        }
+      }
+    },
+    "with_caveat": {
+      "comment": "with_caveat",
+      "match": "\\s*(with)\\s*([a-zA-Z_]*)\\s*",
+      "captures": {
+        "1": {
+          "name": "keyword.class.definition"
+        },
+        "2": {
+          "name": "entity.name.function"
+        }
+      }
+    },
+    "with_expiration": {
+      "comment": "with_expiration",
+      "match": "\\s*(with)\\s*(expiration)\\s*",
+      "captures": {
+        "1": {
+          "name": "keyword.class.definition"
+        },
+        "2": {
+          "name": "keyword.class.definition"
+        }
+      }
     }
   }
 }

--- a/syntaxes/test/full-standard.zed
+++ b/syntaxes/test/full-standard.zed
@@ -1,0 +1,36 @@
+// this is a standard schema that should have every available feature (wildcards, caveats, etc)
+use expiration
+
+definition user {}
+
+definition group {
+	relation member: user with non_expired_grant | user with expiration
+	relation member2: user:* with non_expired_grant
+}
+
+definition document {
+	relation group: group
+    
+	relation aaa: user:* | group#member
+	relation bbb: user:*
+	relation ccc: user:*
+	relation ddd: user:*
+
+
+	// a comment
+	permission view = aaa
+
+	permission nilable = nil
+
+
+	/* another comment */
+	permission view2 = aaa + bbb
+	permission view3 = (aaa + bbb) - (ccc & ddd)
+	permission view4 = group.any(member)
+	permission view5 = group.all(member)
+	permission view6 = group->member
+}
+
+caveat non_expired_grant(name string, description string) {
+  name.matches("-$test") || size(description) >= 100
+}


### PR DESCRIPTION
## Description
- add more rules to SpiceDB grammar
- remove CEL as external dependency to be able to publish to Open VSX. (this should also close https://github.com/authzed/spicedb-vscode/issues/29)

<img width="705" height="417" alt="image" src="https://github.com/user-attachments/assets/da883718-460e-4a39-a8d0-d73e863b1afd" />

## Testing
Before: 

<img width="951" height="780" alt="image" src="https://github.com/user-attachments/assets/829c1c19-bd35-4b3e-972a-14dd57d3bb91" />


After:

<img width="1148" height="888" alt="image" src="https://github.com/user-attachments/assets/f323dfe1-8444-48dc-a7d1-76a649f28edc" />

