### PR TITLE
fix: support prefixes in caveats

### DIFF
--- a/syntaxes/spicedb.tmGrammar.json
+++ b/syntaxes/spicedb.tmGrammar.json
@@ -227,7 +227,7 @@
     "caveat": {
       "comment": "caveat in schema",
       "name": "meta.embedded.block.cel",
-      "begin": "(\\bcaveat\\b)\\s+([a-zA-Z_]\\w*)\\s*\\(([^\\)]*)\\)\\s*(\\{)",
+      "begin": "(\\bcaveat\\b)\\s+(([a-z][\\w]{1,62}[a-z0-9]\\/)*[a-z][\\w]{1,62}[a-z0-9])\\s*\\(([^\\)]*)\\)\\s*(\\{)",
       "beginCaptures": {
         "1": {
           "name": "keyword.function.definition"
@@ -235,10 +235,10 @@
         "2": {
           "name": "entity.name.function"
         },
-        "3": {
+        "4": {
           "patterns": [{ "include": "#caveatParameter" }, { "include": "#caveatTypeName" }, { "include": "#comma" }]
         },
-        "4": {
+        "5": {
           "name": "punctuation.definition.brace"
         }
       },
@@ -290,7 +290,7 @@
     },
     "with_caveat": {
       "comment": "with_caveat",
-      "match": "\\s*(with)\\s*([a-zA-Z_]*)\\s*",
+      "match": "\\s*(with)\\s*(([a-z][\\w]{1,62}[a-z0-9]\\/)*[a-z][\\w]{1,62}[a-z0-9])\\s*",
       "captures": {
         "1": {
           "name": "keyword.class.definition"

--- a/syntaxes/test/full-standard-with-prefixes.zed
+++ b/syntaxes/test/full-standard-with-prefixes.zed
@@ -1,0 +1,36 @@
+// this is a standard schema that should have every available feature (wildcards, caveats, etc) and using prefixes for definitions and caveats
+use expiration
+
+definition acme/user {}
+
+definition acme/group {
+	relation member: acme/user with acme/non_expired_grant | acme/user with expiration
+	relation member2: acme/user:* with acme/non_expired_grant
+}
+
+definition acme/document {
+	relation group: acme/group
+    
+	relation aaa: acme/user:* | acme/group#member
+	relation bbb: acme/user:*
+	relation ccc: acme/user:*
+	relation ddd: acme/user:*
+
+
+	// a comment
+	permission view = aaa
+
+	permission nilable = nil
+
+
+	/* another comment */
+	permission view2 = aaa + bbb
+	permission view3 = (aaa + bbb) - (ccc & ddd)
+	permission view4 = group.any(member)
+	permission view5 = group.all(member)
+	permission view6 = group->member
+}
+
+caveat acme/non_expired_grant(name string, description string) {
+  name.matches("-$test") || size(description) >= 100
+}


### PR DESCRIPTION
Follow-up to https://github.com/authzed/spicedb-vscode/pull/26.

Before: 

<img width="1032" height="830" alt="image" src="https://github.com/user-attachments/assets/453c029b-45b3-4d16-a662-7af2d95fa86c" />


After:
<img width="1242" height="916" alt="image" src="https://github.com/user-attachments/assets/923b8f09-672f-4089-8b5c-d95d3d75dc09" />
