### PR TITLE
fix: reorder grammar patterns for 'with expiration'

### DIFF
--- a/syntaxes/spicedb.tmGrammar.json
+++ b/syntaxes/spicedb.tmGrammar.json
@@ -78,8 +78,8 @@
         { "include": "#indirectRelationType" },
         { "include": "#directRelationType" },
         { "include": "#pipe" },
-        { "include": "#with_caveat" },
         { "include": "#with_expiration" },
+        { "include": "#with_caveat" },
         { "include": "#comment" }
       ]
     },


### PR DESCRIPTION
## Description
Reorder TextMate grammar patterns so `with_expiration` is matched before `with_caveat`. 

Previously, `with_caveat` (which matches `with` + any identifier) was checked first, incorrectly matching `with expiration` as a caveat named "expiration" instead of the expiration keyword.

Fixes #40