### PR TITLE
fix: missing check watches panel

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -2,10 +2,12 @@
 .idea
 .vscode
 .gitignore
-src/check-watch-panel/node_modules
-!src/check-watch-panel/node_modules/@vscode/codicons/dist
 CODE-OF-CONDUCT.md
 build-panels.sh
-download-wasm.sh
 eslint.config.mjs
+syntaxes/test
 src
+# the check watches panel build includes: main.js, main.css, main.wasm, wasm_exec.js
+!src/check-watch-panel/build
+src/check-watch-panel/node_modules
+!src/check-watch-panel/node_modules/@vscode/codicons/dist

--- a/build-panels.sh
+++ b/build-panels.sh
@@ -1,4 +1,19 @@
 set -e
+
+WASM_FILE="src/check-watch-panel/public/main.wasm"
+WASM_URL="https://github.com/authzed/spicedb/releases/download/v1.49.2/development.wasm"
+
+WASM_EXEC_FILE="src/check-watch-panel/public/wasm_exec.js"
+WASM_EXEC_URL="https://raw.githubusercontent.com/golang/go/c61e5e72447b568dd25367f592962c7ebf28b1c7/lib/wasm/wasm_exec.js"
+
+# curl should work on mac, linux, and windows > 10
+if [ ! -f "$WASM_FILE" ]; then
+  curl -fL "$WASM_URL" -o "$WASM_FILE"
+fi
+if [ ! -f "$WASM_EXEC_FILE" ]; then
+  curl -fL "$WASM_EXEC_URL" -o "$WASM_EXEC_FILE"
+fi
+
 cd src/check-watch-panel
 yarn install
 yarn build

--- a/download-wasm.sh
+++ b/download-wasm.sh
@@ -1,2 +1,0 @@
-wget https://github.com/authzed/spicedb/releases/download/v1.44.0/development.wasm -O src/check-watch-panel/public/main.wasm
-wget https://raw.githubusercontent.com/golang/go/c61e5e72447b568dd25367f592962c7ebf28b1c7/lib/wasm/wasm_exec.js -O src/check-watch-panel/public/wasm_exec.js

--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "vscode:build": "vsce package -o spicedb.vsix --no-yarn",
     "vscode:prepublish": "yarn run compile",
     "vscode:publish": "vsce publish --no-yarn",
-    "download-wasm": "./download-wasm.sh",
     "compile": "tsc -p ./ && sh ./build-panels.sh",
     "watch": "tsc -watch -p ./",
     "pretest": "yarn run compile && yarn run lint",

--- a/src/check-watch-panel/package.json
+++ b/src/check-watch-panel/package.json
@@ -33,8 +33,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build && yarn run dist-build",
-    "dist-build": "./dist-build.sh",
+    "build": "react-scripts build && sh dist-build.sh",
     "lint": "eslint --ext .js,.ts && prettier -c .",
     "lint:fix": "eslint --fix --ext .js,.ts && prettier -w .",
     "test": "react-scripts test",

--- a/src/check-watch-panel/src/App.tsx
+++ b/src/check-watch-panel/src/App.tsx
@@ -136,17 +136,11 @@ function App() {
           )}
           {!!activeSchema && !activeYaml && (
             <div style={{ display: 'block', textAlign: 'left' }}>
-              <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-                <i className="codicon codicon-warning"></i>
-                <div>
-                  No valid relationships file with extension <code>.zed.yaml</code> found matching the schema file{' '}
-                  <code>{activeSchemaPath}</code>
-                </div>
-              </div>
               <div style={{ display: 'flex', alignItems: 'center', gap: '10px', marginTop: '20px' }}>
                 <i className="codicon codicon-arrow-circle-right"></i>
                 <div>
-                  To enable the Check Watches panel, please create a YAML file named <code>{activeSchemaPath}.yaml</code>
+                  To enable the Check Watches panel, please create a YAML file named <code>{activeSchemaPath}.yaml</code> and add{' '}
+                  <code>relationships</code> to it.
                 </div>
               </div>
             </div>
@@ -161,7 +155,31 @@ function App() {
           )}
         </>
       )}
-      {isValidFile && hasValidSchemaAndYaml && devService.state.status !== 'ready' && <VSCodeProgressRing />}
+      {isValidFile && hasValidSchemaAndYaml && devService.state.status === 'loading' && <VSCodeProgressRing />}
+      {isValidFile && hasValidSchemaAndYaml && (devService.state.status === 'loaderror' || devService.state.status === 'unsupported') && (
+        <div style={{ display: 'block', textAlign: 'left' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+            <i className="codicon codicon-error"></i>
+            <div style={{ color: '#FF8488' }}>
+              {devService.state.status === 'unsupported'
+                ? 'WebAssembly is not supported in this environment.'
+                : 'Failed to load the SpiceDB developer WASM module.'}
+            </div>
+          </div>
+          <div style={{ marginTop: '10px' }}>
+            The Check Watches panel requires a WASM binary at <code>src/check-watch-panel/build/main.wasm</code>. To download it, run from
+            the SpiceDB repository:
+          </div>
+          <pre
+            style={{ marginTop: '5px', padding: '8px', backgroundColor: 'var(--vscode-textCodeBlock-background)', whiteSpace: 'pre-wrap' }}
+          >
+            GOOS=js GOARCH=wasm go build -o main.wasm ./cmd/spicedb-wasm
+          </pre>
+          <div>
+            Then copy <code>main.wasm</code> into <code>src/check-watch-panel/build/</code>.
+          </div>
+        </div>
+      )}
       {isValidFile && hasValidSchemaAndYaml && devService.state.status === 'ready' && (
         <div style={{ width: '100%' }}>
           <div style={{ position: 'relative', width: '100%' }}>

--- a/src/checkwatchprovider.ts
+++ b/src/checkwatchprovider.ts
@@ -118,8 +118,8 @@ export class CheckWatchProvider implements vscode.WebviewViewProvider {
   private _getHtmlForWebview(webview: vscode.Webview) {
     const cssUri = getUri(webview, this._extensionUri, ['src', 'check-watch-panel', 'build', 'main.css']);
     const scriptUri = getUri(webview, this._extensionUri, ['src', 'check-watch-panel', 'build', 'main.js']);
-    const goScriptUri = getUri(webview, this._extensionUri, ['src', 'check-watch-panel', 'public', 'wasm_exec.js']);
-    const wasmBundleUri = getUri(webview, this._extensionUri, ['src', 'check-watch-panel', 'public', 'main.wasm']);
+    const goScriptUri = getUri(webview, this._extensionUri, ['src', 'check-watch-panel', 'build', 'wasm_exec.js']);
+    const wasmBundleUri = getUri(webview, this._extensionUri, ['src', 'check-watch-panel', 'build', 'main.wasm']);
 
     // From: https://github.com/microsoft/vscode-extension-samples/blob/main/webview-codicons-sample/src/extension.ts
     const codiconsUri = getUri(webview, this._extensionUri, [


### PR DESCRIPTION
<!--
If your PR is not ready to be reviewed or merged, please submit it as a "draft".
-->

## Description

- Closes https://github.com/authzed/spicedb-vscode/issues/48. I accidentally broke this in this diff: https://github.com/authzed/spicedb-vscode/commit/c94827bfbda310592e9f028d327a2048a586796a#diff-0a721cd4753ff50bbbe1237397c3c7692080254fa766268fcc8b05ef633c50bf
- Added a message when check watches panel isn't working because WASM isn't present
- Remove duplicate wasm file (!!!) - it's in `public/` and `build/`


## Testing

Manually

<img width="1306" height="796" alt="image" src="https://github.com/user-attachments/assets/ee96407b-f1b3-4ff1-a7bf-8068ff34d1a0" />

<img width="1306" height="796" alt="image" src="https://github.com/user-attachments/assets/3b6b0340-3159-44dc-9522-5c50d82819ab" />

<img width="1306" height="796" alt="image" src="https://github.com/user-attachments/assets/54b26ee7-6496-410a-b435-1c43a993a12f" />


## References

<!--
GitHub Issue, Discord or Slack threads, etc.
-->