### PR TITLE
fix: support check watches for SpiceDB language mode

### DIFF
--- a/src/check-watch-panel/src/App.tsx
+++ b/src/check-watch-panel/src/App.tsx
@@ -14,6 +14,7 @@ function App() {
   }, []);
 
   const [activeFilePath, setActiveFilePath] = useState<string | undefined>((window as any).ACTIVE_FILE_PATH);
+  const [activeLanguageId, setActiveLanguageId] = useState<string | undefined>((window as any).ACTIVE_LANGUAGE_ID);
 
   const [activeSchemaPath, setActiveSchemaPath] = useState<string | null>(null);
   const [activeSchema, setActiveSchema] = useState<string | null>(null);
@@ -76,6 +77,7 @@ function App() {
 
         case 'activeFile':
           setActiveFilePath(message.filePath);
+          setActiveLanguageId(message.languageId);
       }
     };
 
@@ -110,7 +112,8 @@ function App() {
     liveCheckService.itemUpdated(item);
   };
 
-  const isValidFile = !!activeFilePath && (activeFilePath.endsWith('.zed') || activeFilePath.endsWith('.zed.yaml'));
+  const isValidFile =
+    !!activeFilePath && (activeFilePath.endsWith('.zed') || activeFilePath.endsWith('.zed.yaml') || activeLanguageId === 'spicedb');
   const hasValidSchemaAndYaml = !!activeSchema && !!activeYaml && !yamlIssue;
 
   return (

--- a/src/checkwatchprovider.ts
+++ b/src/checkwatchprovider.ts
@@ -29,7 +29,8 @@ export class CheckWatchProvider implements vscode.WebviewViewProvider {
         case 'ready':
           if (
             vscode.window.activeTextEditor?.document.uri.fsPath.endsWith('.zed') ||
-            vscode.window.activeTextEditor?.document.uri.fsPath.endsWith('.zed.yaml')
+            vscode.window.activeTextEditor?.document.uri.fsPath.endsWith('.zed.yaml') ||
+            vscode.window.activeTextEditor?.document.languageId === 'spicedb'
           ) {
             this.performUpdate(vscode.window.activeTextEditor?.document.uri.fsPath);
           }
@@ -52,6 +53,8 @@ export class CheckWatchProvider implements vscode.WebviewViewProvider {
     } else if (fsPath.endsWith('.yaml')) {
       yamlContentsPath = fsPath;
       schemaContentsPath = fsPath.replace('.yaml', '');
+    } else if (vscode.window.activeTextEditor?.document.languageId === 'spicedb') {
+      schemaContentsPath = fsPath;
     }
 
     let schemaContents = '';
@@ -91,7 +94,8 @@ export class CheckWatchProvider implements vscode.WebviewViewProvider {
 
   public setActiveFile(filePath: string | undefined) {
     if (this._view) {
-      this._view.webview.postMessage({ type: 'activeFile', filePath });
+      const languageId = vscode.window.activeTextEditor?.document.languageId;
+      this._view.webview.postMessage({ type: 'activeFile', filePath, languageId });
     }
   }
 
@@ -133,6 +137,7 @@ export class CheckWatchProvider implements vscode.WebviewViewProvider {
 
     const nonce = getNonce();
     const activeFilePath = vscode.window.activeTextEditor?.document.uri.fsPath ?? '';
+    const activeLanguageId = vscode.window.activeTextEditor?.document.languageId ?? '';
 
     return `<!DOCTYPE html>
 			<html lang="en">
@@ -145,6 +150,7 @@ export class CheckWatchProvider implements vscode.WebviewViewProvider {
 				<script>
 					window.WASM_BUNDLE_URI = '${wasmBundleUri}';
 					window.ACTIVE_FILE_PATH = '${activeFilePath}';
+					window.ACTIVE_LANGUAGE_ID = '${activeLanguageId}';
 				</script>
                 <script src="${goScriptUri}"></script>
 			</head>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,7 +29,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     vscode.workspace.onDidChangeTextDocument((e: vscode.TextDocumentChangeEvent) => {
-      if (e.document.uri.fsPath.endsWith('.zed')) {
+      if (e.document.uri.fsPath.endsWith('.zed') || e.document.languageId === 'spicedb') {
         if (vscode.window.activeTextEditor?.document.uri.fsPath === e.document.uri.fsPath) {
           checkWatchProvider.setActiveSchema(e.document.uri.fsPath, e.document.getText());
         }


### PR DESCRIPTION
## Description

Check watches now work when the file doesn't have a `.zed` extension, as long as the language mode is set to SpiceDB. Previously the extension only checked file extensions.

BEFORE
<img width="1435" height="889" alt="Screenshot 2026-03-27 at 11 30 44 AM" src="https://github.com/user-attachments/assets/9d4b5a60-4a7c-4258-bb9a-525c01bcb36a" />

AFTER
<img width="1435" height="889" alt="Screenshot 2026-03-27 at 11 32 41 AM" src="https://github.com/user-attachments/assets/c2ad5ba1-2915-405a-a79c-2bf31683eaee" />


## Testing

Manually

Fixes #28