### PR TITLE
feat: add yaml support

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,18 @@
         ]
       },
       {
+        "id": "spicedb-yaml",
+        "aliases": [
+          "SpiceDB YAML"
+        ],
+        "extensions": [
+          ".zed.yaml"
+        ],
+        "filenamePatterns": [
+          "*.zed.yaml"
+        ]
+      },
+      {
         "id": "spicedb",
         "aliases": [
           "SpiceDB",
@@ -51,6 +63,24 @@
         "language": "cel",
         "scopeName": "source.cel",
         "path": "./syntaxes/cel.tmGrammar.json"
+      },
+      {
+        "language": "spicedb-yaml",
+        "scopeName": "source.spicedb-yaml",
+        "path": "./syntaxes/spicedb-yaml.tmGrammar.json",
+        "embeddedLanguages": {
+          "meta.embedded.block.spicedb": "spicedb"
+        }
+      },
+      {
+        "scopeName": "spicedb-yaml.injection",
+        "path": "./syntaxes/spicedb-yaml-injection.tmGrammar.json",
+        "injectTo": [
+          "source.spicedb-yaml"
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.block.spicedb": "spicedb"
+        }
       },
       {
         "language": "spicedb",
@@ -104,9 +134,16 @@
           "when": "view == spicedb.checkWatchView"
         }
       ]
+    },
+    "configurationDefaults": {
+      "files.associations": {
+        "*.zed.yaml": "spicedb-yaml"
+      }
     }
   },
-  "activationEvents": [],
+  "activationEvents": [
+    "onStartupFinished"
+  ],
   "main": "./out/extension.js",
   "scripts": {
     "vscode:build": "vsce package -o spicedb.vsix --no-yarn",

--- a/src/binary.ts
+++ b/src/binary.ts
@@ -8,7 +8,7 @@ import { promisify } from 'util';
 
 const execFileAsync = promisify(execFile);
 
-export const MIN_SPICEDB_VERSION = '1.51.1';
+export const MIN_SPICEDB_VERSION = '1.52.0';
 
 export async function languageServerBinaryPath(_context: vscode.ExtensionContext): Promise<string | undefined> {
   const config = vscode.workspace.getConfiguration('spicedb');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,8 +6,18 @@ import { type ResolvedReference, Resolver, parse } from '@authzed/spicedb-parser
 import { checkSpicedbVersion, getInstallCommand, languageServerBinaryPath } from './binary';
 import { CheckWatchProvider } from './checkwatchprovider';
 
+function reassignZedYamlLanguage(doc: vscode.TextDocument) {
+  if (doc.fileName.endsWith('.zed.yaml') && doc.languageId !== 'spicedb-yaml') {
+    vscode.languages.setTextDocumentLanguage(doc, 'spicedb-yaml');
+  }
+}
+
 export function activate(context: vscode.ExtensionContext) {
   console.log('spicedb-vscode is now active');
+
+  // Reassign language for any already-open .zed.yaml files detected as plain yaml
+  vscode.workspace.textDocuments.forEach(reassignZedYamlLanguage);
+  context.subscriptions.push(vscode.workspace.onDidOpenTextDocument(reassignZedYamlLanguage));
 
   const checkWatchProvider = new CheckWatchProvider(context.extensionUri);
 
@@ -199,9 +209,12 @@ async function startLanguageServer(context: vscode.ExtensionContext) {
   };
 
   const clientOptions: LanguageClientOptions = {
-    documentSelector: [{ scheme: 'file', language: 'spicedb' }],
+    documentSelector: [
+      { scheme: 'file', language: 'spicedb' },
+      { scheme: 'file', language: 'spicedb-yaml' },
+    ],
     synchronize: {
-      fileEvents: vscode.workspace.createFileSystemWatcher('**/.zed'),
+      fileEvents: vscode.workspace.createFileSystemWatcher('**/*.zed{,.yaml}'),
     },
   };
 

--- a/syntaxes/spicedb-yaml-injection.tmGrammar.json
+++ b/syntaxes/spicedb-yaml-injection.tmGrammar.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "scopeName": "spicedb-yaml.injection",
+  "injectionSelector": "L:source.spicedb-yaml",
+  "patterns": [{ "include": "#schema-block" }],
+  "repository": {
+    "schema-block": {
+      "begin": "(['\"]?schema['\"]?)(:\\s*)([|>][-+0-9]*)\\s*$",
+      "beginCaptures": {
+        "1": { "name": "entity.name.tag.yaml" },
+        "2": { "name": "punctuation.separator.key-value.mapping.yaml" },
+        "3": { "name": "keyword.control.flow.block-scalar.literal.yaml" }
+      },
+      "while": "^(\\s|$)",
+      "contentName": "meta.embedded.block.spicedb",
+      "patterns": [{ "include": "source.spicedb" }]
+    }
+  }
+}

--- a/syntaxes/spicedb-yaml.tmGrammar.json
+++ b/syntaxes/spicedb-yaml.tmGrammar.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "SpiceDB YAML",
+  "scopeName": "source.spicedb-yaml",
+  "patterns": [{ "include": "source.yaml" }]
+}

--- a/syntaxes/test/full-standard.zed.yaml
+++ b/syntaxes/test/full-standard.zed.yaml
@@ -1,0 +1,14 @@
+---
+schema: |-
+  definition user {}
+  definition doc {
+    relation vieww: user
+    relation blah: user
+    }
+
+assertions:
+  assertTrue:
+    - 'doc:1#admin@user:maria'
+
+relationships: |-
+  doc:1#vieww@user:maria

--- a/syntaxes/test/withSchemaFile.zed.yaml
+++ b/syntaxes/test/withSchemaFile.zed.yaml
@@ -1,0 +1,2 @@
+---
+schemaFile: 'imported.zed'


### PR DESCRIPTION
## Description

Support `.zed.yaml` files:
- highlight them properly (schema section is highlighted as spicedb DSL)
- react to changes and re-run validation and assertions

## Testing

Locally:

https://github.com/user-attachments/assets/71da8545-73f0-4521-aeec-e1ac7cf70df7
