### PR TITLE
fix: invalid PCRE escape in permission grammar regex

### DIFF
--- a/syntaxes/spicedb.tmGrammar.json
+++ b/syntaxes/spicedb.tmGrammar.json
@@ -131,7 +131,7 @@
     },
     "permission": {
       "comment": "definition of a permission",
-      "begin": "(\\permission\\b)\\s+([a-zA-Z_]\\w*)\\s*(\\=)\\s*",
+      "begin": "(permission\\b)\\s+([a-zA-Z_]\\w*)\\s*(=)\\s*",
       "beginCaptures": {
         "1": {
           "name": "keyword.function.relation"


### PR DESCRIPTION
The `permission` keyword pattern used `\\permission` which PCRE parses as the start of a Unicode property escape (`\p{...}`). Works in VS Code (Oniguruma is lenient about unknown escapes), but breaks GitHub Linguist's grammar compiler, which uses PCRE strictly.

Drops the unnecessary `\` before `permission` and `=`. No behavior change in VS Code.

Found while preparing a Linguist PR to add `.zed` syntax highlighting on github.com.