### PR TITLE
chore: drop unnecessary backslash escapes in grammar regexes

### DIFF
--- a/syntaxes/cel.tmGrammar.json
+++ b/syntaxes/cel.tmGrammar.json
@@ -299,7 +299,7 @@
         },
         {
           "name": "keyword.operator.arithmetic.cel",
-          "match": "(\\+|\\-|\\*|\\/|\\%|\\!)"
+          "match": "(\\+|-|\\*|\\/|%|!)"
         }
       ]
     }

--- a/syntaxes/spicedb.tmGrammar.json
+++ b/syntaxes/spicedb.tmGrammar.json
@@ -62,7 +62,7 @@
     },
     "relation": {
       "comment": "definition of a relation",
-      "begin": "(\\brelation\\b)\\s+([a-zA-Z_]\\w*)\\s*(\\:)",
+      "begin": "(\\brelation\\b)\\s+([a-zA-Z_]\\w*)\\s*(:)",
       "beginCaptures": {
         "1": {
           "name": "keyword.variable.relation"
@@ -74,7 +74,7 @@
           "name": "punctuation.definition.colon"
         }
       },
-      "end": "(?<=\\;|\\n)",
+      "end": "(?<=;|\\n)",
       "patterns": [
         { "include": "#wildcardRelationType" },
         { "include": "#indirectRelationType" },
@@ -92,7 +92,7 @@
     },
     "wildcardRelationType": {
       "comment": "wildcard relation type",
-      "match": "([a-zA-Z_]\\w*)(\\:)(\\*)",
+      "match": "([a-zA-Z_]\\w*)(:)(\\*)",
       "captures": {
         "1": {
           "name": "entity.name.class"
@@ -143,7 +143,7 @@
           "name": "punctuation.definition.equal"
         }
       },
-      "end": "(?<=\\;|\\n)",
+      "end": "(?<=;|\\n)",
       "patterns": [
         { "include": "#comment" },
         { "include": "#arrow_alternative" },
@@ -174,7 +174,7 @@
     },
     "permissionOperator": {
       "comment": "permission operator",
-      "match": "\\s*(\\+|\\-|\\&)\\s*",
+      "match": "\\s*(\\+|-|&)\\s*",
       "captures": {
         "1": {
           "name": "keyword.operator.logical"
@@ -183,7 +183,7 @@
     },
     "arrow": {
       "comment": "arrow",
-      "match": "\\s*([a-zA-Z_]\\w*)(\\-\\>)([a-zA-Z_]\\w*)\\s*",
+      "match": "\\s*([a-zA-Z_]\\w*)(->)([a-zA-Z_]\\w*)\\s*",
       "captures": {
         "1": {
           "name": "entity.name.variable"
@@ -275,7 +275,7 @@
     },
     "comma": {
       "comment": "comma",
-      "match": "\\s*\\,\\s*",
+      "match": "\\s*,\\s*",
       "name": "punctuation.definition.comma"
     },
     "use": {


### PR DESCRIPTION
Cosmetic cleanup of unnecessary backslash escapes in `syntaxes/spicedb.tmGrammar.json` and `syntaxes/cel.tmGrammar.json`. Drops `\` before characters that aren't regex metacharacters: `:`, `;`, `,`, `-` (outside char classes), `&`, `>`, `!`, `%`.

These escapes are decorative — they match the same literal characters either way in Oniguruma (VS Code) and PCRE (Linguist). No behavior change in highlighting.

Follow-up to #65, which fixed the one unnecessary escape (`\permission`) that *did* break PCRE because `\p` is reserved for Unicode property escapes. The remaining ones don't break PCRE today but are equally unnecessary.