### PR TITLE
fix: scope single-line /* */ as block comment

### DIFF
--- a/syntaxes/spicedb.tmGrammar.json
+++ b/syntaxes/spicedb.tmGrammar.json
@@ -19,15 +19,11 @@
       "patterns": [{ "include": "#lineComment" }, { "include": "#blockComment" }],
       "repository": {
         "lineComment": {
-          "patterns": [{ "include": "#doubleSlashLineComment" }, { "include": "#slashDotLineComment" }],
+          "patterns": [{ "include": "#doubleSlashLineComment" }],
           "repository": {
             "doubleSlashLineComment": {
               "match": "\\/\\/.*",
               "name": "comment.line.double-slash.spicedb"
-            },
-            "slashDotLineComment": {
-              "match": "\\/\\*.*\\*\\/",
-              "name": "comment.line.spicedb"
             }
           }
         },


### PR DESCRIPTION
The `slashDotLineComment` rule was matching single-line `/* ... */` and scoping it as `comment.line.spicedb`, but those are still block comments. The existing `blockComment` (begin `/*`, end `*/`) handles single-line cases just fine since TextMate begin/end rules can match on the same line, so the redundant rule is removed.

Affects fixtures `full-standard.zed:30` and `full-standard-with-prefixes.zed:26` - they now correctly scope as `comment.block.spicedb`. Visible highlighting in standard themes is unchanged because they key on the `comment` ancestor.