### PR TITLE
fix: tighten relationRef anchoring and permission word boundary

### DIFF
--- a/syntaxes/spicedb.tmGrammar.json
+++ b/syntaxes/spicedb.tmGrammar.json
@@ -165,7 +165,7 @@
     },
     "relationRef": {
       "comment": "relation reference",
-      "match": "([a-zA-Z_]\\w*)",
+      "match": "([a-zA-Z_]\\w*)\\b(?!->|\\.(?:any|all)\\()",
       "captures": {
         "1": {
           "name": "entity.name.variable"

--- a/syntaxes/spicedb.tmGrammar.json
+++ b/syntaxes/spicedb.tmGrammar.json
@@ -131,7 +131,7 @@
     },
     "permission": {
       "comment": "definition of a permission",
-      "begin": "(permission\\b)\\s+([a-zA-Z_]\\w*)\\s*(=)\\s*",
+      "begin": "(\\bpermission\\b)\\s+([a-zA-Z_]\\w*)\\s*(=)\\s*",
       "beginCaptures": {
         "1": {
           "name": "keyword.function.relation"


### PR DESCRIPTION
Two related regex-correctness fixes in the permission rule.

**1. Anchor `relationRef` so it can't shadow arrow rules.** It matched any identifier and only worked because the arrow / `.any()` / `.all()` rules were listed first in the patterns. Switched to a negative lookahead so it explicitly skips identifiers immediately followed by `->`, `.any(`, or `.all(` — correctness is now regex-local instead of depending on include order. The `\b` matters: without it, Oniguruma backtracks `\w*` into the middle of an identifier when the lookahead fails (matching `grou` for `group->member`).

**2. Add the missing leading `\b` to the `permission` keyword.** `definition`, `relation`, and `caveat` all start their `begin` regex with `\b<keyword>\b`; `permission` was the odd one out (`(permission\b)`). One-character fix for consistency.