### PR TITLE
fix: keep watches panel populated when switching to a non-spicedb tab

### DIFF
--- a/src/checkwatchprovider.ts
+++ b/src/checkwatchprovider.ts
@@ -4,6 +4,8 @@ import { Uri, Webview } from 'vscode';
 import fs from 'fs';
 import fsp from 'fs/promises';
 
+import { isSpiceDbDocument } from './spicedbDocument';
+
 function getUri(webview: Webview, extensionUri: Uri, pathList: string[]) {
   return webview.asWebviewUri(Uri.joinPath(extensionUri, ...pathList));
 }
@@ -26,15 +28,13 @@ export class CheckWatchProvider implements vscode.WebviewViewProvider {
 
     webviewView.webview.onDidReceiveMessage((data) => {
       switch (data.type) {
-        case 'ready':
-          if (
-            vscode.window.activeTextEditor?.document.uri.fsPath.endsWith('.zed') ||
-            vscode.window.activeTextEditor?.document.uri.fsPath.endsWith('.zed.yaml') ||
-            vscode.window.activeTextEditor?.document.languageId === 'spicedb'
-          ) {
-            this.performUpdate(vscode.window.activeTextEditor?.document.uri.fsPath);
+        case 'ready': {
+          const active = vscode.window.activeTextEditor;
+          if (active && isSpiceDbDocument(active.document.uri.fsPath, active.document.languageId)) {
+            this.performUpdate(active.document.uri.fsPath);
           }
           break;
+        }
       }
     });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import { type ResolvedReference, Resolver, parse } from '@authzed/spicedb-parser
 
 import { checkSpicedbVersion, getInstallCommand, languageServerBinaryPath } from './binary';
 import { CheckWatchProvider } from './checkwatchprovider';
+import { isSpiceDbDocument } from './spicedbDocument';
 
 function reassignZedYamlLanguage(doc: vscode.TextDocument) {
   if (doc.fileName.endsWith('.zed.yaml') && doc.languageId !== 'spicedb-yaml') {
@@ -31,7 +32,11 @@ export function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     vscode.window.onDidChangeActiveTextEditor((editor) => {
-      if (editor) {
+      if (!editor) return;
+      // Only refresh the panel for SpiceDB-related files; switching to an
+      // unrelated tab (e.g. a Markdown file) used to wipe the panel back to
+      // its empty state and hide the active watches.
+      if (isSpiceDbDocument(editor.document.uri.fsPath, editor.document.languageId)) {
         checkWatchProvider.performUpdate(editor.document.uri.fsPath);
       }
     }),

--- a/src/spicedbDocument.ts
+++ b/src/spicedbDocument.ts
@@ -1,0 +1,8 @@
+// isSpiceDbDocument reports whether a document represents a SpiceDB-related
+// file the check-watch panel knows how to render: a `.zed` schema, a
+// `.zed.yaml` relationships file, or any file the user has tagged with the
+// `spicedb` language id. Kept as a pure predicate over its inputs so it can
+// be unit-tested without standing up the VS Code test harness.
+export function isSpiceDbDocument(fsPath: string, languageId: string): boolean {
+  return fsPath.endsWith('.zed') || fsPath.endsWith('.zed.yaml') || languageId === 'spicedb';
+}

--- a/src/test/spicedbDocument.test.ts
+++ b/src/test/spicedbDocument.test.ts
@@ -1,0 +1,22 @@
+import * as assert from 'assert';
+
+import { isSpiceDbDocument } from '../spicedbDocument';
+
+suite('isSpiceDbDocument', () => {
+  test('accepts a .zed file regardless of language id', () => {
+    assert.strictEqual(isSpiceDbDocument('/x/schema.zed', 'plaintext'), true);
+  });
+
+  test('accepts a .zed.yaml file regardless of language id', () => {
+    assert.strictEqual(isSpiceDbDocument('/x/schema.zed.yaml', 'yaml'), true);
+  });
+
+  test('accepts any file whose language id is `spicedb`', () => {
+    assert.strictEqual(isSpiceDbDocument('/x/schema.txt', 'spicedb'), true);
+  });
+
+  test('rejects an unrelated file even when its path contains `zed`', () => {
+    assert.strictEqual(isSpiceDbDocument('/x/notes.md', 'markdown'), false);
+    assert.strictEqual(isSpiceDbDocument('/x/zedlike.txt', 'plaintext'), false);
+  });
+});


### PR DESCRIPTION
Closes #63.